### PR TITLE
Added Jinja as a dependecy for install in order to be able to use on buildout

### DIFF
--- a/openerp_proxy/version.py
+++ b/openerp_proxy/version.py
@@ -1,1 +1,1 @@
-version = "0.6.3"  # pragma: no cover
+version = "0.6.3.dev1"  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(name='openerp_proxy',
           'setuptools>=18',
           'requests>=2.7',
           'ipython>=4',       # repr extension
+          'Jinja2',
       ],
       tests_require=[
           'mock',


### PR DESCRIPTION
In order to be able to use this extension on a buildout installation inside a virtualenvironment, I needed to add Jinja2 as an install_dependency.
